### PR TITLE
fixed:修复编译支付宝百度小程序报错

### DIFF
--- a/packages/regular-template-compiler/package.json
+++ b/packages/regular-template-compiler/package.json
@@ -9,6 +9,10 @@
   "scripts": {},
   "keywords": [],
   "author": "",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/kaola-fed/megalo-aot/tree/master/packages/regular-template-compiler"
+  },
   "license": "MIT",
   "dependencies": {
     "html-minifier": "^3.5.21",

--- a/packages/target/lib/platforms/alipay/codegen/page.json.js
+++ b/packages/target/lib/platforms/alipay/codegen/page.json.js
@@ -4,7 +4,7 @@ const {
   convertPageConfig
 } = require( '../convert-config' )
 
-module.exports = function ( { config, file } ) {
+module.exports = function ( { config = {}, file } ) {
   const _config = composePlatformConfig( config, 'alipay' )
   let converted = {}
   if (file === 'app') {

--- a/packages/target/lib/platforms/swan/codegen/page.json.js
+++ b/packages/target/lib/platforms/swan/codegen/page.json.js
@@ -1,6 +1,6 @@
 const composePlatformConfig = require( '../../shared/utils/composePlatformConfig' )
 
-module.exports = function ( { config } ) {
+module.exports = function ( { config = {} } ) {
   const _config = composePlatformConfig( config, 'swan' )
   return JSON.stringify( _config, 0, 2 )
 }

--- a/packages/target/package.json
+++ b/packages/target/package.json
@@ -12,6 +12,10 @@
   "scripts": {},
   "keywords": [],
   "author": "",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/kaola-fed/megalo-aot/tree/master/packages/target"
+  },
   "license": "MIT",
   "dependencies": {
     "@megalo/regular-template-compiler": "^0.1.0",


### PR DESCRIPTION
加了repository后，在vscode的package.json里，鼠标悬浮到库上，可以显示跳转到库的源代码链接：
![image](https://user-images.githubusercontent.com/10484248/49568910-5eadcc80-f96d-11e8-9f81-86df16e79693.png)
