### PR TITLE
版本号升级策略修改

### DIFF
--- a/packages/regular-template-compiler/package.json
+++ b/packages/regular-template-compiler/package.json
@@ -20,7 +20,7 @@
     "nanoid": "^1.0.2",
     "prettier": "^1.13.4",
     "regularjs": "^0.6.0",
-    "vue-template-compiler": "2.5.17",
+    "vue-template-compiler": "^2.5.17",
     "loader-utils": "^1.1.0"
   },
   "devDependencies": {}


### PR DESCRIPTION
vue升级到2.5.19版本了，而依赖的vue-template-compiler还是固定的2.5.17版本，会导致编译报错。
解决方法：
- 采用兼容性升级策略（本次pull request的方法）
- 锁死依赖的vue版本为2.5.17
